### PR TITLE
fix: adding ability to share state across multiple sibling states

### DIFF
--- a/src/State.js
+++ b/src/State.js
@@ -28,10 +28,17 @@ export default class State extends Component {
     render() {
         const state = this.props.parseState ? this.props.parseState(this.state) : this.state;
 
-        return (
-            <div>
-                {cloneElement(this.props.children, state)}
-            </div>
-        );
-    }
+		return (
+			<div>
+				{React.children.count > 1
+					? React.Children.map(this.props.children, (child, i) => {
+						if (typeof child === 'string') {
+							return child;
+						}
+						return cloneElement(child, state);
+					  })
+					: cloneElement(child, state)}
+			</div>
+		);
+	}
 }


### PR DESCRIPTION
Proposal:
We had a specific case where we wanted to share state across sibling components in storybook that work together such as search bar/listings.

Let me know if you have alternates to help with this.