### PR TITLE
Change instructions to install as dev dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ### Getting Started
 
 ```sh
-npm install --save @sambego/storybook-state
+npm install --save-dev @sambego/storybook-state
 ```
 
 First you will need to create a new store, to save the state and handle updates.


### PR DESCRIPTION
Thanks for this nice package!

According to the [docs of Storybook](https://storybook.js.org/docs/guides/guide-react/#add-storybookreact), Storybook should be installed as a dev dependency. Same applies for Storybook State, I think. What do others think?